### PR TITLE
Fix fatal error when saving nodes with audio recordings

### DIFF
--- a/src/Plugin/Field/FieldWidget/NamePronunciationRecorderWidget.php
+++ b/src/Plugin/Field/FieldWidget/NamePronunciationRecorderWidget.php
@@ -132,7 +132,7 @@ class NamePronunciationRecorderWidget extends WidgetBase {
           \Drupal::service('file_system')->prepareDirectory($directory, \Drupal\Core\File\FileSystemInterface::CREATE_DIRECTORY);
 
           // Save the file.
-          $file = file_save_data($data, $directory . '/' . $filename, \Drupal\Core\File\FileSystemInterface::EXISTS_REPLACE);
+          $file = \Drupal::service('file.repository')->writeData($data, $directory . '/' . $filename, \Drupal\Core\File\FileSystemInterface::EXISTS_REPLACE);
 
           if ($file) {
             $value['target_id'] = $file->id();


### PR DESCRIPTION
Replace deprecated file_save_data() with Drupal 10/11 file.repository service. The file_save_data() function doesn't exist in Drupal 10/11 and needs to be replaced with \Drupal::service('file.repository')->writeData().

Fixes #4