### PR TITLE
Fix play button on node edit page

### DIFF
--- a/src/Plugin/Field/FieldWidget/NamePronunciationRecorderWidget.php
+++ b/src/Plugin/Field/FieldWidget/NamePronunciationRecorderWidget.php
@@ -99,6 +99,11 @@ class NamePronunciationRecorderWidget extends WidgetBase {
           '#theme' => 'name_pronunciation_audio_player',
           '#audio_url' => $file->createFileUrl(),
           '#file_mime_type' => $file->getMimeType(),
+          '#attached' => [
+            'library' => [
+              'name_pronunciation/player',
+            ],
+          ],
         ];
       }
     }


### PR DESCRIPTION
Attach the player JavaScript library when displaying current recordings in the widget form element. This ensures the play button works on the node edit page, matching the functionality already present on the node view page.

Fixes #9