### PR TITLE
Add audio upload field to name pronunciation

### DIFF
--- a/src/Plugin/Field/FieldFormatter/NamePronunciationPlayerFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/NamePronunciationPlayerFormatter.php
@@ -76,8 +76,18 @@ class NamePronunciationPlayerFormatter extends FormatterBase {
     $elements = [];
 
     foreach ($items as $delta => $item) {
-      /** @var \Drupal\file\FileInterface $file */
-      $file = $item->entity;
+      $file = NULL;
+
+      // Prioritize uploaded file over recorded file.
+      if (!empty($item->upload_target_id)) {
+        /** @var \Drupal\file\FileInterface $file */
+        $file = \Drupal::entityTypeManager()->getStorage('file')->load($item->upload_target_id);
+      }
+      // Fall back to recorded file if no upload exists.
+      elseif (!empty($item->target_id)) {
+        /** @var \Drupal\file\FileInterface $file */
+        $file = $item->entity;
+      }
 
       if ($file) {
         $elements[$delta] = [

--- a/src/Plugin/Field/FieldType/NamePronunciationItem.php
+++ b/src/Plugin/Field/FieldType/NamePronunciationItem.php
@@ -52,6 +52,10 @@ class NamePronunciationItem extends EntityReferenceItem {
       ->setLabel(t('Description'))
       ->setDescription(t('A description of the pronunciation (e.g., "First name", "Last name", "Full name")'));
 
+    $properties['upload_target_id'] = DataDefinition::create('integer')
+      ->setLabel(t('Uploaded file ID'))
+      ->setDescription(t('The ID of the uploaded audio file'));
+
     return $properties;
   }
 
@@ -65,6 +69,12 @@ class NamePronunciationItem extends EntityReferenceItem {
       'description' => 'A description of the pronunciation.',
       'type' => 'varchar',
       'length' => 255,
+    ];
+
+    $schema['columns']['upload_target_id'] = [
+      'description' => 'The ID of the uploaded audio file.',
+      'type' => 'int',
+      'unsigned' => TRUE,
     ];
 
     return $schema;

--- a/src/Plugin/Field/FieldWidget/NamePronunciationRecorderWidget.php
+++ b/src/Plugin/Field/FieldWidget/NamePronunciationRecorderWidget.php
@@ -38,6 +38,18 @@ class NamePronunciationRecorderWidget extends WidgetBase {
       '#maxlength' => 255,
     ];
 
+    // Add file upload field.
+    $element['upload_target_id'] = [
+      '#type' => 'managed_file',
+      '#title' => $this->t('Upload audio file'),
+      '#description' => $this->t('Upload a pre-recorded audio file instead of recording. This will be used instead of a recorded pronunciation if provided.'),
+      '#default_value' => !empty($items[$delta]->upload_target_id) ? [$items[$delta]->upload_target_id] : NULL,
+      '#upload_location' => 'public://pronunciations',
+      '#upload_validators' => [
+        'file_validate_extensions' => [$this->getFieldSetting('file_extensions')],
+      ],
+    ];
+
     $element['recorder'] = [
       '#type' => 'container',
       '#attributes' => [
@@ -81,7 +93,34 @@ class NamePronunciationRecorderWidget extends WidgetBase {
       '#attributes' => ['class' => ['recorder-preview', 'hidden']],
     ];
 
-    // If there's an existing file, show the current recording.
+    // If there's an existing uploaded file, show it.
+    if (!empty($items[$delta]->upload_target_id)) {
+      /** @var \Drupal\file\FileInterface $file */
+      $file = \Drupal::entityTypeManager()->getStorage('file')->load($items[$delta]->upload_target_id);
+      if ($file) {
+        $element['current_upload'] = [
+          '#type' => 'container',
+          '#attributes' => ['class' => ['current-pronunciation-upload']],
+        ];
+
+        $element['current_upload']['label'] = [
+          '#markup' => '<strong>' . $this->t('Current uploaded file:') . '</strong>',
+        ];
+
+        $element['current_upload']['audio'] = [
+          '#theme' => 'name_pronunciation_audio_player',
+          '#audio_url' => $file->createFileUrl(),
+          '#file_mime_type' => $file->getMimeType(),
+          '#attached' => [
+            'library' => [
+              'name_pronunciation/player',
+            ],
+          ],
+        ];
+      }
+    }
+
+    // If there's an existing recording, show it.
     if (!empty($items[$delta]->target_id)) {
       /** @var \Drupal\file\FileInterface $file */
       $file = $items[$delta]->entity;
@@ -121,6 +160,17 @@ class NamePronunciationRecorderWidget extends WidgetBase {
    */
   public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
     foreach ($values as &$value) {
+      // Handle the uploaded file.
+      if (!empty($value['upload_target_id'])) {
+        // The managed_file element returns an array with the file ID.
+        if (is_array($value['upload_target_id'])) {
+          $value['upload_target_id'] = reset($value['upload_target_id']);
+        }
+      }
+      else {
+        $value['upload_target_id'] = NULL;
+      }
+
       // Handle the audio data and create a file entity.
       if (!empty($value['audio_data'])) {
         $audio_data = $value['audio_data'];
@@ -150,6 +200,7 @@ class NamePronunciationRecorderWidget extends WidgetBase {
       // Clean up form elements that shouldn't be saved.
       unset($value['recorder']);
       unset($value['current']);
+      unset($value['current_upload']);
     }
 
     return $values;


### PR DESCRIPTION
This commit adds a new sub-field to the name pronunciation field that allows users to upload pre-recorded audio files as an alternative to recording.

Changes:
- Added upload_target_id property and schema column to NamePronunciationItem
- Added managed_file upload field to NamePronunciationRecorderWidget
- Updated NamePronunciationPlayerFormatter to prioritize uploaded files over recorded files
- Both recording and upload functionality work in parallel

Fixes #12