### PR TITLE
claude/add-gitlab-ci-drupal-QLXgv

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,5 @@
+include:
+  - project: $_GITLAB_TEMPLATES_REPO
+    ref: $_GITLAB_TEMPLATES_REF
+    file:
+      - '/includes/include.drupalci.main.yml'


### PR DESCRIPTION
Add minimal GitLab CI configuration that uses Drupal Association's templates to automatically run:
- PHP coding standards (PHPCS)
- Static analysis (PHPStan)
- PHPUnit tests against Drupal 10 and 11
- Various PHP/database combinations